### PR TITLE
Fix @PKG_NAME@_INCLUDE_DIR variable

### DIFF
--- a/patch/config.cmake.in
+++ b/patch/config.cmake.in
@@ -3,7 +3,8 @@ if (@PKG_NAME@_CONFIG_INCLUDED)
 endif()
 set(@PKG_NAME@_CONFIG_INCLUDED TRUE)
 
-set(@PKG_NAME@_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
+get_filename_component(include "${@PKG_NAME@_DIR}/../../../include" ABSOLUTE)
+set(@PKG_NAME@_INCLUDE_DIRS ${include})
 set(@PKG_NAME@_DIALECTS @PKG_MAVLINK_DIALECTS@)
 set(@PKG2_NAME@_DIALECTS @PKG2_MAVLINK_DIALECTS@)
 


### PR DESCRIPTION
The previous approach hardcoded the path to the include directory and cross
compilation using a sysroot directory would fail. This patch takes the
resulting config files generated from other ROS packages as reference.