### PR TITLE
Fail if user calls find_package() with wrong case

### DIFF
--- a/patch/config.cmake.in
+++ b/patch/config.cmake.in
@@ -1,3 +1,13 @@
+# Force case-sensitive search
+string(COMPARE EQUAL "@PKG_NAME@" "${CMAKE_FIND_PACKAGE_NAME}" case_sensitive_match)
+if (NOT case_sensitive_match)
+  if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+    message(AUTHOR_WARNING "got '${CMAKE_FIND_PACKAGE_NAME}', use case-sensitive find_package(@PKG_NAME@) instead")
+  endif()
+  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND false)
+  return()
+endif()
+
 if (@PKG_NAME@_CONFIG_INCLUDED)
   return()
 endif()


### PR DESCRIPTION
The generated variable `mavlink_INCLUDE_DIRS` is only correct if the user calls `find_package()` with lowercase `mavlink`. This PR makes `find_package()` fail if the user uses a different case. A new release to melodic with this change would be appreciated.

The issue was discovered on melodic when trying to build [rotors_hil_interface](https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_hil_interface/CMakeLists.txt). That project uses a call to `find_package(Mavlink)`. When `find_package()` invokes this file it has set the variable `${Mavlink_DIR}` (note the case). This config file sets `mavlink_INCLUDE_DIRS` to the value of `${mavlink_DIR}/../../../include}`, but `${mavlink_DIR}` is unset. As a result `mavlink_INCLUDE_DIRS` is set to the path `/include` instead of `/opt/ros/melodic/include`.

This fix uses `${CMAKE_FIND_PACKAGE_NAME}` which is mentioned in the `find_package()` documentation for [cmake 3.1 and above](https://cmake.org/cmake/help/v3.1/command/find_package.html). I think that means this patch is OK for ROS lunar and above since [Lunar targets cmake 3.5.1 and above](http://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021)