### PR TITLE
Another fix for finding Python on cmake>=3.12

### DIFF
--- a/patch/CMakeLists.txt
+++ b/patch/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 if (NOT CMAKE_VERSION VERSION_LESS "3.12")
     find_package(Python${Py_VERSION} COMPONENTS Interpreter)
+    set(Python_EXECUTABLE "${Python${Py_VERSION}_EXECUTABLE}")
 else()
     # find libraries with cmake modules
     find_package(PythonInterp ${Py_VERSION} REQUIRED)


### PR DESCRIPTION
The variables set by `FindPythonX` all begin with `PythonX_`.

Here is the documentation: https://github.com/Kitware/CMake/blob/v3.12.0/Modules/FindPython3.cmake#L53-L54